### PR TITLE
less strict response check

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var gcpMetadata = {
       return request(reqOpts, function (err, res, body) {
         if (err) {
           callback(err)
-        } else if (!res || res.headers['Metadata-Flavor'] !== 'Google') {
+        } else if (!res) {
           callback(new Error('Invalid response from metadata service'))
         } else if (res.statusCode !== 200) {
           callback(new Error('Unsuccessful response status code'), res)

--- a/index.test.js
+++ b/index.test.js
@@ -5,10 +5,7 @@ var extend = require('extend')
 var proxyquire = require('proxyquire')
 
 var VALID_RESPONSE = {
-  statusCode: 200,
-  headers: {
-    'Metadata-Flavor': 'Google'
-  }
+  statusCode: 200
 }
 
 describe('gcpMetadata', function () {


### PR DESCRIPTION
We should be using caseless header checks; however, there is very
little value in the header check anyway because since we are
contacting the Google metadata service. Requiring a header in the
response makes it harder to nock the metadata service.

Fixes: https://github.com/stephenplusplus/gcp-metadata/issues/6