### PR TITLE
fix: remove Error from type of callback error object

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -124,7 +124,7 @@ describe('gcpMetadata', () => {
   });
 
   it('should return the request error', (done) => {
-    const ERROR = 'fake error';
+    const ERROR = Object.assign(new Error('fake error'), {code: 'ETEST'});
     const TYPE = 'type';
 
     const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
@@ -134,6 +134,9 @@ describe('gcpMetadata', () => {
     };
 
     getMetadata((err) => {
+      // TSC fails if code isn't defined on err.
+      assert.ok(err && typeof (err.code) === 'string');
+
       assert.strictEqual(err, ERROR);
       done();
     });

--- a/index.ts
+++ b/index.ts
@@ -7,8 +7,8 @@ const BASE_URL = 'http://metadata.google.internal/computeMetadata/v1';
 export type Options = _request.CoreOptions&{property?: string, uri?: string};
 
 export type Callback =
-    (error: Error|NodeJS.ErrnoException|null,
-     response?: _request.RequestResponse, metadataProp?: string) => void;
+    (error: NodeJS.ErrnoException|null, response?: _request.RequestResponse,
+     metadataProp?: string) => void;
 
 export function _buildMetadataAccessor(type: string) {
   return function metadataAccessor(


### PR DESCRIPTION
`Error|NodeJS.ErrnoException` turns out not to be the equivalent of `NodeJS.ErrnoException`: a function with the signature defined by `Callback` will always see `error` as an `Error` object, as it is a supertype of `ErrnoException`.

@ofrobots PTAL.