### PR TITLE
feat: switch to promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,26 @@
 $ npm install --save gcp-metadata
 ```
 ```js
-var gcpMetadata = require('gcp-metadata')
+const gcpMetadata = require('gcp-metadata');
 ```
 
 #### Access all metadata
 ```js
-gcpMetadata.instance(function(err, response, metadata) {
-  // All metadata properties
-})
+const res = await gcpMetadata.instance();
+console.log(res.data); // ... All metadata properties
 ```
 
 #### Access specific properties
 ```js
-gcpMetadata.instance('hostname', function(err, response, metadata) {
-  // All metadata properties
-})
+const res = await gcpMetadata.instance('hostname');
+console.log(res.data) // ...All metadata properties
 ```
 
 #### Access specific properties with query parameters
 ```js
-gcpMetadata.instance({
+const res = await gcpMetadata.instance({
   property: 'tags',
   params: { alt: 'text' }
-}, function(err, response, metadata) {
-  // Tags as newline-delimited list
-})
+});
+console.log(res.data) // ...Tags as newline-delimited list
 ```

--- a/package.json
+++ b/package.json
@@ -41,11 +41,9 @@
     "@types/extend": "^3.0.0",
     "@types/nock": "^9.1.2",
     "@types/node": "^8.0.31",
-    "@types/pify": "^3.0.0",
     "ava": "^0.25.0",
     "gts": "^0.5.1",
     "nock": "^9.1.6",
-    "pify": "^3.0.0",
     "typescript": "^2.5.3"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,6 @@ export const BASE_URL = HOST_ADDRESS + BASE_PATH;
 export type Options = AxiosRequestConfig&
     {[index: string]: {} | string | undefined, property?: string, uri?: string};
 
-export type Callback =
-    (error: NodeJS.ErrnoException|null, response?: AxiosResponse<string>,
-     metadataProp?: string) => void;
-
 // Accepts an options object passed from the user to the API.  In the
 // previous version of the API, it referred to a `Request` options object.
 // Now it refers to an Axios Request Config object.  This is here to help
@@ -27,69 +23,55 @@ function validate(options: Options) {
       const e = `'${
           pair.invalid}' is not a valid configuration option. Please use '${
           pair.expected}' instead. This library is using Axios for requests. Please see https://github.com/axios/axios to learn more about the valid request options.`;
-      return new Error(e);
+      throw new Error(e);
     }
   }
-  return null;
 }
 
-export function _buildMetadataAccessor(type: string) {
-  return function metadataAccessor(
-      options: string|Options|Callback, callback?: Callback) {
-    if (!options) {
-      options = {};
-    }
-
-    if (typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-
-    if (typeof options === 'string') {
-      options = {property: options};
-    }
-
-    let property = '';
-    if (typeof options === 'object' && options.property) {
-      property = '/' + options.property;
-    }
-
-    const err = validate(options);
-    if (err) {
-      setImmediate(callback!, err);
-      return;
-    }
-
-    const ax = axios.create();
-    rax.attach(ax);
-    const baseOpts = {
-      url: `${BASE_URL}/${type}${property}`,
-      headers: {'Metadata-Flavor': 'Google'},
-      raxConfig: {noResponseRetries: 0}
-    };
-    const reqOpts = extend(true, baseOpts, options);
-    delete (reqOpts as {property: string}).property;
-    ax.request(reqOpts)
-        .then(res => {
-          // NOTE: node.js converts all incoming headers to lower case.
-          if (res.headers['metadata-flavor'] !== 'Google') {
-            callback!(new Error(
-                `Invalid response from metadata service: incorrect Metadata-Flavor header.`));
-          } else if (!res.data) {
-            callback!(new Error('Invalid response from the metadata service'));
-          } else {
-            callback!(null, res, res.data);
-          }
-        })
-        .catch((err: AxiosError) => {
-          if (err.response && err.response.status !== 200) {
-            callback!(new Error('Unsuccessful response status code'));
-          } else {
-            callback!(err);
-          }
-        });
+async function metadataAccessor(type: string, options?: string|Options) {
+  options = options || {};
+  if (typeof options === 'string') {
+    options = {property: options};
+  }
+  let property = '';
+  if (typeof options === 'object' && options.property) {
+    property = '/' + options.property;
+  }
+  validate(options);
+  const ax = axios.create();
+  rax.attach(ax);
+  const baseOpts = {
+    url: `${BASE_URL}/${type}${property}`,
+    headers: {'Metadata-Flavor': 'Google'},
+    raxConfig: {noResponseRetries: 0}
   };
+  const reqOpts = extend(true, baseOpts, options);
+  delete (reqOpts as {property: string}).property;
+  return ax.request(reqOpts)
+      .then(res => {
+        // NOTE: node.js converts all incoming headers to lower case.
+        if (res.headers['metadata-flavor'] !== 'Google') {
+          throw new Error(
+              `Invalid response from metadata service: incorrect Metadata-Flavor header.`);
+        } else if (!res.data) {
+          throw new Error('Invalid response from the metadata service');
+        }
+        return res;
+      })
+      .catch((err: AxiosError) => {
+        if (err.response && err.response.status !== 200) {
+          throw new Error('Unsuccessful response status code');
+        }
+        throw err;
+      });
 }
 
-export const instance = _buildMetadataAccessor('instance');
-export const project = _buildMetadataAccessor('project');
+
+
+export function instance(options?: string|Options) {
+  return metadataAccessor('instance', options);
+}
+
+export function project(options?: string|Options) {
+  return metadataAccessor('project', options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as rax from 'retry-axios';
 export const HOST_ADDRESS = 'http://metadata.google.internal';
 export const BASE_PATH = '/computeMetadata/v1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
+export const HEADER_NAME = 'Metadata-Flavor';
 
 export type Options = AxiosRequestConfig&
     {[index: string]: {} | string | undefined, property?: string, uri?: string};
@@ -50,9 +51,9 @@ async function metadataAccessor(type: string, options?: string|Options) {
   return ax.request(reqOpts)
       .then(res => {
         // NOTE: node.js converts all incoming headers to lower case.
-        if (res.headers['metadata-flavor'] !== 'Google') {
-          throw new Error(
-              `Invalid response from metadata service: incorrect Metadata-Flavor header.`);
+        if (res.headers[HEADER_NAME.toLowerCase()] !== 'Google') {
+          throw new Error(`Invalid response from metadata service: incorrect ${
+              HEADER_NAME} header.`);
         } else if (!res.data) {
           throw new Error('Invalid response from the metadata service');
         }
@@ -65,8 +66,6 @@ async function metadataAccessor(type: string, options?: string|Options) {
         throw err;
       });
 }
-
-
 
 export function instance(options?: string|Options) {
   return metadataAccessor('instance', options);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,14 +2,12 @@ import test from 'ava';
 import {AxiosResponse} from 'axios';
 import * as extend from 'extend';
 import * as nock from 'nock';
-import * as pify from 'pify';
+import * as gcp from '../src';
 
-import * as gcpMetadata from '../src';
-
-const HOST = gcpMetadata.HOST_ADDRESS;
-const PATH = gcpMetadata.BASE_PATH;
-const BASE_URL = gcpMetadata.BASE_URL;
-const TYPE = 'type';
+const HOST = gcp.HOST_ADDRESS;
+const PATH = gcp.BASE_PATH;
+const BASE_URL = gcp.BASE_URL;
+const TYPE = 'instance';
 const PROPERTY = 'property';
 const metadataFlavor = 'Metadata-Flavor';
 
@@ -25,14 +23,13 @@ test.afterEach.always(async t => {
 });
 
 test.serial('should create the correct accessors', async t => {
-  t.is(typeof gcpMetadata.instance, 'function');
-  t.is(typeof gcpMetadata.project, 'function');
+  t.is(typeof gcp.instance, 'function');
+  t.is(typeof gcp.project, 'function');
 });
 
 test.serial('should access all the metadata properly', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope = nock(HOST).get(`${PATH}/${TYPE}`).reply(200, {}, HEADERS);
-  const res = await pify(getMetadata)();
+  const res = await gcp.instance();
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}`);
   t.is(res.config.headers[metadataFlavor], 'Google');
@@ -40,10 +37,9 @@ test.serial('should access all the metadata properly', async t => {
 });
 
 test.serial('should access a specific metadata property', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope =
       nock(HOST).get(`${PATH}/${TYPE}/${PROPERTY}`).reply(200, {}, HEADERS);
-  const res = await pify(getMetadata)(PROPERTY);
+  const res = await gcp.instance(PROPERTY);
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
 });
@@ -51,24 +47,22 @@ test.serial('should access a specific metadata property', async t => {
 test.serial(
     'should accept an object with property and query fields', async t => {
       const QUERY = {key: 'value'};
-      const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
       const scope = nock(HOST)
                         .get(`${PATH}/${TYPE}/${PROPERTY}`)
                         .query(QUERY)
                         .reply(200, {}, HEADERS);
-      const res = await pify(getMetadata)({property: PROPERTY, params: QUERY});
+      const res = await gcp.instance({property: PROPERTY, params: QUERY});
       scope.done();
       t.is(JSON.stringify(res.config.params), JSON.stringify(QUERY));
       t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
     });
 
 test.serial('should extend the request options', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const options = {property: PROPERTY, headers: {'Custom-Header': 'Custom'}};
   const originalOptions = extend(true, {}, options);
   const scope =
       nock(HOST).get(`${PATH}/${TYPE}/${PROPERTY}`).reply(200, {}, HEADERS);
-  const res = await pify(getMetadata)(options);
+  const res = await gcp.instance(options);
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
   t.is(res.config.headers['Custom-Header'], 'Custom');
@@ -76,61 +70,54 @@ test.serial('should extend the request options', async t => {
 });
 
 test.serial('should return the request error', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope =
       nock(HOST).get(`${PATH}/${TYPE}`).times(2).reply(500, undefined, HEADERS);
-  await t.throws(pify(getMetadata)(), 'Unsuccessful response status code');
+  await t.throws(gcp.instance(), 'Unsuccessful response status code');
   scope.done();
 });
 
 test.serial('should return error when res is empty', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope = nock(HOST).get(`${PATH}/${TYPE}`).reply(200, null, HEADERS);
-  await t.throws(pify(getMetadata)());
+  await t.throws(gcp.instance());
   scope.done();
 });
 
 test.serial('should return error when flavor header is incorrect', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope = nock(HOST).get(`${PATH}/${TYPE}`).reply(200, {}, {
     'metadata-flavor': 'Hazelnut'
   });
   await t.throws(
-      pify(getMetadata)(),
+      gcp.instance(),
       `Invalid response from metadata service: incorrect Metadata-Flavor header.`);
   scope.done();
 });
 
 test.serial('should return error if statusCode is not 200', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope = nock(HOST).get(`${PATH}/${TYPE}`).reply(418, {}, HEADERS);
-  await t.throws(pify(getMetadata)(), 'Unsuccessful response status code');
+  await t.throws(gcp.instance(), 'Unsuccessful response status code');
   scope.done();
 });
 
 test.serial('should retry if the initial request fails', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scopes = [
     nock(HOST).get(`${PATH}/${TYPE}`).reply(500),
     nock(HOST).get(`${PATH}/${TYPE}`).reply(200, {}, HEADERS)
   ];
-  const res = await pify(getMetadata)();
+  const res = await gcp.instance();
   scopes.forEach(s => s.done());
   t.is(res.config.url, `${BASE_URL}/${TYPE}`);
 });
 
 test.serial('should throw if request options are passed', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   // tslint:disable-next-line no-any
-  await t.throws(pify((gcpMetadata as any).instance)({qs: {one: 'two'}}), e => {
+  await t.throws((gcp as any).instance({qs: {one: 'two'}}), e => {
     return e.message.startsWith('\'qs\' is not a valid');
   });
 });
 
 test.serial('should not retry on DNS errors', async t => {
-  const getMetadata = gcpMetadata._buildMetadataAccessor(TYPE);
   const scope =
       nock(HOST).get(`${PATH}/${TYPE}`).replyWithError({code: 'ETIMEDOUT'});
-  await t.throws(pify(getMetadata)());
+  await t.throws(gcp.instance());
   scope.done();
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava';
-import {AxiosResponse} from 'axios';
 import * as extend from 'extend';
 import * as nock from 'nock';
 import * as gcp from '../src';
@@ -7,9 +6,9 @@ import * as gcp from '../src';
 const HOST = gcp.HOST_ADDRESS;
 const PATH = gcp.BASE_PATH;
 const BASE_URL = gcp.BASE_URL;
+const HEADER_NAME = gcp.HEADER_NAME;
 const TYPE = 'instance';
 const PROPERTY = 'property';
-const metadataFlavor = 'Metadata-Flavor';
 
 // NOTE: nodejs switches all incoming header names to lower case.
 const HEADERS = {
@@ -32,8 +31,8 @@ test.serial('should access all the metadata properly', async t => {
   const res = await gcp.instance();
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}`);
-  t.is(res.config.headers[metadataFlavor], 'Google');
-  t.is(res.headers[metadataFlavor.toLowerCase()], 'Google');
+  t.is(res.config.headers[HEADER_NAME], 'Google');
+  t.is(res.headers[HEADER_NAME.toLowerCase()], 'Google');
 });
 
 test.serial('should access a specific metadata property', async t => {


### PR DESCRIPTION
This could be contentious :)   I was having a ton of trouble getting this to work with both callbacks and promises.  I took at a look at the dependents...  and they're all libs we own:
https://www.npmjs.com/browse/depended/gcp-metadata

How about we just ruthlessly break this API and only support promise based programming?