### PR TITLE
fix: use v1beta1 instead of v1 to support GCF

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import * as extend from 'extend';
 import * as rax from 'retry-axios';
 
 export const HOST_ADDRESS = 'http://metadata.google.internal.';
-export const BASE_PATH = '/computeMetadata/v1';
+export const BASE_PATH = '/computeMetadata/v1beta1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
 
 export type Options = AxiosRequestConfig&


### PR DESCRIPTION
This updates the url to use v1beta1, which makes things work on the GCF.   