### PR TITLE
test: switch to ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pretest": "npm run compile",
     "posttest": "npm run check",
     "prepare": "npm run compile",
-    "test": "mocha build/test"
+    "test": "ava build/test"
   },
   "keywords": [
     "google cloud platform",
@@ -39,12 +39,13 @@
   },
   "devDependencies": {
     "@types/extend": "^3.0.0",
-    "@types/mocha": "^2.2.43",
     "@types/nock": "^9.1.2",
     "@types/node": "^8.0.31",
+    "@types/pify": "^3.0.0",
+    "ava": "^0.25.0",
     "gts": "^0.5.1",
-    "mocha": "^3.2.0",
     "nock": "^9.1.6",
+    "pify": "^3.0.0",
     "typescript": "^2.5.3"
   },
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export function _buildMetadataAccessor(type: string) {
           // NOTE: node.js converts all response headers to lower case.
           if (res.headers['metadata-flavor'] !== 'Google') {
             callback!(new Error(
-                `The 'Metadata-Flavor' header is not set to 'Google'.`));
+                `Invalid response from metadata service: incorrect Metadata-Flavor header.`));
           } else if (!res.data) {
             callback!(new Error('Invalid response from the metadata service'));
           } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export function _buildMetadataAccessor(type: string) {
     delete (reqOpts as {property: string}).property;
     ax.request(reqOpts)
         .then(res => {
-          // NOTE: node.js converts all response headers to lower case.
+          // NOTE: node.js converts all incoming headers to lower case.
           if (res.headers['metadata-flavor'] !== 'Google') {
             callback!(new Error(
                 `Invalid response from metadata service: incorrect Metadata-Flavor header.`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,16 +64,17 @@ export function _buildMetadataAccessor(type: string) {
     rax.attach(ax);
     const baseOpts = {
       url: `${BASE_URL}/${type}${property}`,
-      headers: {'metadata-flavor': 'Google'},
+      headers: {'Metadata-Flavor': 'Google'},
       raxConfig: {noResponseRetries: 0}
     };
     const reqOpts = extend(true, baseOpts, options);
     delete (reqOpts as {property: string}).property;
     ax.request(reqOpts)
         .then(res => {
+          // NOTE: node.js converts all response headers to lower case.
           if (res.headers['metadata-flavor'] !== 'Google') {
             callback!(new Error(
-                `The 'metadata-flavor' header is not set to 'Google'.`));
+                `The 'Metadata-Flavor' header is not set to 'Google'.`));
           } else if (!res.data) {
             callback!(new Error('Invalid response from the metadata service'));
           } else {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import test from 'ava';
+import {AxiosResponse} from 'axios';
 import * as extend from 'extend';
 import * as nock from 'nock';
 import * as pify from 'pify';
@@ -10,6 +11,9 @@ const PATH = gcpMetadata.BASE_PATH;
 const BASE_URL = gcpMetadata.BASE_URL;
 const TYPE = 'type';
 const PROPERTY = 'property';
+const metadataFlavor = 'Metadata-Flavor';
+
+// NOTE: nodejs switches all header names to lower case.
 const HEADERS = {
   'metadata-flavor': 'Google'
 };
@@ -31,7 +35,8 @@ test.serial('should access all the metadata properly', async t => {
   const res = await pify(getMetadata)();
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}`);
-  t.is(res.config.headers['metadata-flavor'], 'Google');
+  t.is(res.config.headers[metadataFlavor], 'Google');
+  t.is(res.headers[metadataFlavor.toLowerCase()], 'Google');
 });
 
 test.serial('should access a specific metadata property', async t => {
@@ -41,7 +46,6 @@ test.serial('should access a specific metadata property', async t => {
   const res = await pify(getMetadata)(PROPERTY);
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
-  t.is(res.config.headers['metadata-flavor'], 'Google');
 });
 
 test.serial(
@@ -55,7 +59,6 @@ test.serial(
       const res = await pify(getMetadata)({property: PROPERTY, params: QUERY});
       scope.done();
       t.is(JSON.stringify(res.config.params), JSON.stringify(QUERY));
-      t.is(res.config.headers['metadata-flavor'], 'Google');
       t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
     });
 
@@ -94,7 +97,7 @@ test.serial('should return error when flavor header is incorrect', async t => {
   });
   await t.throws(
       pify(getMetadata)(),
-      `The 'metadata-flavor' header is not set to 'Google'.`);
+      `The 'Metadata-Flavor' header is not set to 'Google'.`);
   scope.done();
 });
 
@@ -114,7 +117,6 @@ test.serial('should retry if the initial request fails', async t => {
   const res = await pify(getMetadata)();
   scopes.forEach(s => s.done());
   t.is(res.config.url, `${BASE_URL}/${TYPE}`);
-  t.is(res.config.headers['metadata-flavor'], 'Google');
 });
 
 test.serial('should throw if request options are passed', async t => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,7 +23,6 @@ test.afterEach.always(async t => {
 test.serial('should create the correct accessors', async t => {
   t.is(typeof gcpMetadata.instance, 'function');
   t.is(typeof gcpMetadata.project, 'function');
-  t.pass();
 });
 
 test.serial('should access all the metadata properly', async t => {
@@ -43,7 +42,6 @@ test.serial('should access a specific metadata property', async t => {
   scope.done();
   t.is(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
   t.is(res.config.headers['metadata-flavor'], 'Google');
-  t.pass();
 });
 
 test.serial(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -97,7 +97,7 @@ test.serial('should return error when flavor header is incorrect', async t => {
   });
   await t.throws(
       pify(getMetadata)(),
-      `The 'Metadata-Flavor' header is not set to 'Google'.`);
+      `Invalid response from metadata service: incorrect Metadata-Flavor header.`);
   scope.done();
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,7 +13,7 @@ const TYPE = 'type';
 const PROPERTY = 'property';
 const metadataFlavor = 'Metadata-Flavor';
 
-// NOTE: nodejs switches all header names to lower case.
+// NOTE: nodejs switches all incoming header names to lower case.
 const HEADERS = {
   'metadata-flavor': 'Google'
 };


### PR DESCRIPTION
`assert.throws` doesn't seem to handle async/await.  To work around that in the current tests, I was trying to do a catch and assert.  That was causing issues (as found [here](https://github.com/stephenplusplus/gcp-metadata/pull/24#discussion_r166140281).  To properly test throws, I moved us over to ava.  This uncovered a whole bunch of issues that are addressed here as well.  

The `.serial` stuff is required because of our use of `nock`.