### PR TITLE
fix: use the v1 path and remove trailing dot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import axios, {AxiosError, AxiosRequestConfig, AxiosResponse} from 'axios';
 import * as extend from 'extend';
 import * as rax from 'retry-axios';
 
-export const HOST_ADDRESS = 'http://metadata.google.internal.';
-export const BASE_PATH = '/computeMetadata/v1beta1';
+export const HOST_ADDRESS = 'http://metadata.google.internal';
+export const BASE_PATH = '/computeMetadata/v1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
 
 export type Options = AxiosRequestConfig&


### PR DESCRIPTION
After a fair bit of manual testing, we figured out that the v1/ path on GCF works ONLY if you're passing the right request headers. The tests are now fixed up to verify this.  We also found that GCF doesn't respond to the trailing dot for DNS lookups, so we need to roll that perf change back. 