### PR TITLE
fix: retry 3 times instead of once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ async function metadataAccessor(type: string, options?: string|Options) {
   const baseOpts = {
     url: `${BASE_URL}/${type}${property}`,
     headers: Object.assign({}, HEADERS),
-    raxConfig: {noResponseRetries: 0}
+    raxConfig: {noResponseRetries: 0, instance: ax}
   };
   const reqOpts = extend(true, baseOpts, options);
   delete (reqOpts as {property: string}).property;


### PR DESCRIPTION
There was a funny little bug hiding in here, where retries were only happening once.  The fix is to pass the instance object along with the config.  I also fixed up the tests to make sure we catch this in the future. 