### PR TITLE
scripts.prepare -> scripts.prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "gts clean",
     "pretest": "npm run compile",
     "posttest": "npm run check",
-    "prepare": "npm run compile",
+    "prepublishOnly": "npm run compile",
     "test": "ava build/test"
   },
   "keywords": [


### PR DESCRIPTION
Here're the npm definitions:

> prepare: Run both BEFORE the package is packed and published, and on local npm install
> prepublishOnly:  Run BEFORE the package is prepared and packed, ONLY on npm publish

I think we want prepubilshOnly, so that every `npm install` doesn't run the compilation step.