### PR TITLE
chore: TypeScript 2.7 and TypeScript test

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,20 @@
   },
   "devDependencies": {
     "@types/extend": "^3.0.0",
+    "@types/ncp": "^2.0.1",
     "@types/nock": "^9.1.2",
     "@types/node": "^8.0.31",
+    "@types/pify": "^3.0.0",
+    "@types/tmp": "0.0.33",
     "ava": "^0.25.0",
     "codecov": "^3.0.0",
     "gts": "^0.5.1",
+    "ncp": "^2.0.0",
     "nock": "^9.1.6",
     "nyc": "^11.4.1",
-    "typescript": "^2.5.3"
+    "pify": "^3.0.0",
+    "tmp": "0.0.33",
+    "typescript": "^2.7.0"
   },
   "engines": {
     "node": ">=4"

--- a/test/fixtures/kitchen/package.json
+++ b/test/fixtures/kitchen/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gcp-metadata-fixture",
+  "version": "1.0.0",
+  "description": "An app we're using to test the library. ",
+  "scripts": {
+    "check": "gts check",
+    "clean": "gts clean",
+    "compile": "tsc -p .",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check",
+    "start": "node build/src/index.js"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "gcp-metadata": "file:./gcp-metadata.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "^8.0.53",
+    "typescript": "^2.6.1",
+    "gts": "^0.5.1"
+  }
+}

--- a/test/fixtures/kitchen/src/index.ts
+++ b/test/fixtures/kitchen/src/index.ts
@@ -1,0 +1,14 @@
+import * as gcp from 'gcp-metadata';
+// uncomment the line below during development
+//import * as gcp from '../../../../build/src/index';
+
+const header = gcp.HEADER_NAME;
+const headers = gcp.HEADERS;
+
+async function main() {
+  const v = await gcp.instance('/somepath');
+}
+
+gcp.project('something').then(x => console.log);
+
+main().catch(console.error);

--- a/test/fixtures/kitchen/tsconfig.json
+++ b/test/fixtures/kitchen/tsconfig.json
@@ -6,12 +6,9 @@
   },
   "include": [
     "src/*.ts",
-    "src/**/*.ts",
-    "test/*.ts",
-    "test/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "test/fixtures"
+    "node_modules"
   ]
 }

--- a/test/kitchen.test.ts
+++ b/test/kitchen.test.ts
@@ -1,0 +1,55 @@
+import test from 'ava';
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import {ncp} from 'ncp';
+import * as pify from 'pify';
+import * as tmp from 'tmp';
+
+const rename = pify(fs.rename);
+const ncpp = pify(ncp);
+const keep = true;  //!!process.env.GCPM_KEEP_TEMPDIRS;
+const stagingDir = tmp.dirSync({keep, unsafeCleanup: true});
+const stagingPath = stagingDir.name;
+const pkg = require('../../package.json');
+
+const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
+    Promise<void> => {
+      return new Promise((resolve, reject) => {
+        cp.spawn(command, args, Object.assign(options, {stdio: 'inherit'}))
+            .on('close',
+                (code, signal) => {
+                  if (code === 0) {
+                    resolve();
+                  } else {
+                    reject(
+                        new Error(`Spawn failed with an exit code of ${code}`));
+                  }
+                })
+            .on('error', err => {
+              reject(err);
+            });
+      });
+    };
+
+/**
+ * Create a staging directory with temp fixtures used to test on a fresh
+ * application.
+ */
+test('should be able to use the d.ts', async t => {
+  console.log(`${__filename} staging area: ${stagingPath}`);
+  await spawnp('npm', ['pack']);
+  const tarball = `${pkg.name}-${pkg.version}.tgz`;
+  await rename(tarball, `${stagingPath}/${pkg.name}.tgz`);
+  await ncpp('test/fixtures/kitchen', `${stagingPath}/`);
+  await spawnp('npm', ['install'], {cwd: `${stagingPath}/`});
+  t.pass();
+});
+
+/**
+ * CLEAN UP - remove the staging directory when done.
+ */
+test.after('cleanup staging', () => {
+  if (!keep) {
+    stagingDir.removeCallback();
+  }
+});


### PR DESCRIPTION
I noticed that the greenkeeper PR to https://github.com/google/google-auth-library-nodejs/pull/288 was failing, and it looked like an issue with the generated d.ts.  It turned out the answer in this case was to upgrade that lib to TypeScript 2.7, but it made me realize we should probably have a d.ts test in this lib like the others. 