### PR TITLE
feat: retry 3 times on network errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ function validate(options: Options) {
   }
 }
 
-async function metadataAccessor(type: string, options?: string|Options) {
+async function metadataAccessor(
+    type: string, options?: string|Options, noResponseRetries = 3) {
   options = options || {};
   if (typeof options === 'string') {
     options = {property: options};
@@ -46,7 +47,7 @@ async function metadataAccessor(type: string, options?: string|Options) {
   const baseOpts = {
     url: `${BASE_URL}/${type}${property}`,
     headers: Object.assign({}, HEADERS),
-    raxConfig: {noResponseRetries: 0, instance: ax}
+    raxConfig: {noResponseRetries, instance: ax}
   };
   const reqOpts = extend(true, baseOpts, options);
   delete (reqOpts as {property: string}).property;
@@ -85,7 +86,7 @@ export async function isAvailable() {
     // Attempt to read instance metadata. As configured, this will
     // retry 3 times if there is a valid response, and fail fast
     // if there is an ETIMEDOUT or ENOTFOUND error.
-    await instance();
+    await metadataAccessor('instance', undefined, 0);
     return true;
   } catch (err) {
     return false;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,11 +117,15 @@ test.serial('should throw if request options are passed', async t => {
   });
 });
 
-test.serial('should not retry on DNS errors', async t => {
-  const scope =
-      nock(HOST).get(`${PATH}/${TYPE}`).replyWithError({code: 'ETIMEDOUT'});
-  await t.throws(gcp.instance());
+test.serial('should retry on DNS errors', async t => {
+  const scope = nock(HOST)
+                    .get(`${PATH}/${TYPE}`)
+                    .replyWithError({code: 'ETIMEDOUT'})
+                    .get(`${PATH}/${TYPE}`)
+                    .reply(200, {}, HEADERS);
+  const res = await gcp.instance();
   scope.done();
+  t.truthy(res.data);
 });
 
 test.serial(


### PR DESCRIPTION
Updating this to match the current behavior in google-auth-library.  We want to fail fast on network errors when checking if it's on GCE using `isAvailable`, but retry 3 times if it's a call to instance() or project().  This way checks that happen on non-GCE machines fail fast, but real queries are offered a little protection. 