### PR TITLE
fix: do not swallow unexpected errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export async function isAvailable() {
     await metadataAccessor('instance', undefined, 0);
     return true;
   } catch (err) {
-    return false;
+    // Failure to resolve the metadata service means that it is not available.
+    if (err.code && (err.code === 'ENOTFOUND' || err.code === 'ENOENT')) {
+      return false;
+    }
+    // Throw unexpected errors.
+    throw err;
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -150,10 +150,26 @@ test.serial(
     });
 
 test.serial(
-    'should fail fast on isAvailable if a network err is returned', async t => {
+    'should fail fast on isAvailable if ENOTFOUND is returned', async t => {
       const scope =
           nock(HOST).get(`${PATH}/${TYPE}`).replyWithError({code: 'ENOTFOUND'});
       const isGCE = await gcp.isAvailable();
       scope.done();
       t.false(isGCE);
     });
+
+test.serial(
+    'should fail fast on isAvailable if ENOENT is returned', async t => {
+      const scope =
+          nock(HOST).get(`${PATH}/${TYPE}`).replyWithError({code: 'ENOENT'});
+      const isGCE = await gcp.isAvailable();
+      scope.done();
+      t.false(isGCE);
+    });
+
+test.serial('should throw on unexpected errors', async t => {
+  const scope =
+      nock(HOST).get(`${PATH}/${TYPE}`).replyWithError({code: '🤡'});
+  await t.throws(gcp.isAvailable());
+  scope.done();
+});


### PR DESCRIPTION
Failure to resolve the metadata service means that it is not available,
but right now we are swallowing all errors which makes it harder to
diagnose issues with detecting the environment.

This change is needed to debug the root cause of the failure to get auth credentials in https://github.com/googleapis/nodejs-logging-winston/issues/1#issuecomment-400640124.