### PR TITLE
fix: quarantine axios config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,23 +19,23 @@ const isAvailable = await gcpMetadata.isAvailable();
 
 #### Access all metadata
 ```js
-const res = await gcpMetadata.instance();
-console.log(res.data); // ... All metadata properties
+const data = await gcpMetadata.instance();
+console.log(data); // ... All metadata properties
 ```
 
 #### Access specific properties
 ```js
-const res = await gcpMetadata.instance('hostname');
-console.log(res.data) // ...All metadata properties
+const data = await gcpMetadata.instance('hostname');
+console.log(data) // ...All metadata properties
 ```
 
 #### Access specific properties with query parameters
 ```js
-const res = await gcpMetadata.instance({
+const data = await gcpMetadata.instance({
   property: 'tags',
   params: { alt: 'text' }
 });
-console.log(res.data) // ...Tags as newline-delimited list
+console.log(data) // ...Tags as newline-delimited list
 ```
 
 [circle]: https://circleci.com/gh/stephenplusplus/gcp-metadata

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ console.log(data); // ... All metadata properties
 #### Access specific properties
 ```js
 const data = await gcpMetadata.instance('hostname');
-console.log(data) // ...All metadata properties
+console.log(data) // ...Instance hostname
 ```
 
 #### Access specific properties with query parameters

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-metadata",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Get the metadata from a Google Cloud Platform environment",
   "repository": "stephenplusplus/gcp-metadata",
   "main": "./build/src/index.js",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.18.0",
-    "extend": "^3.0.1",
     "retry-axios": "0.3.2"
   },
   "devDependencies": {
-    "@types/extend": "^3.0.0",
     "@types/mocha": "^5.2.4",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^9.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,17 +15,6 @@ export interface Options {
   property?: string;
 }
 
-export interface Response<T> {
-  data: T;
-  status: number;
-  statusText: string;
-  headers: http.OutgoingHttpHeaders;
-  config: {
-    url: string; headers: http.OutgoingHttpHeaders;
-    params: {[index: string]: string};
-  };
-}
-
 // Accepts an options object passed from the user to the API.  In the
 // previous version of the API, it referred to a `Request` options object.
 // Now it refers to an Axios Request Config object.  This is here to help
@@ -46,8 +35,7 @@ function validate(options: Options) {
 }
 
 async function metadataAccessor<T>(
-    type: string, options?: string|Options,
-    noResponseRetries = 3): Promise<Response<T>> {
+    type: string, options?: string|Options, noResponseRetries = 3): Promise<T> {
   options = options || {};
   if (typeof options === 'string') {
     options = {property: options};
@@ -85,7 +73,7 @@ async function metadataAccessor<T>(
             }
             throw err;
           });
-  return normalizeResponse<T>(res);
+  return res.data;
 }
 
 // tslint:disable-next-line no-any
@@ -116,22 +104,4 @@ export async function isAvailable() {
     // Throw unexpected errors.
     throw err;
   }
-}
-
-/**
- * Converts an Axios response to a normal response.
- * @param orig The original response from Axios.
- */
-function normalizeResponse<T>(orig: AxiosResponse<T>): Response<T> {
-  return {
-    data: orig.data,
-    status: orig.status,
-    statusText: orig.statusText,
-    headers: orig.headers,
-    config: {
-      url: orig.config.url!,
-      headers: orig.config.headers,
-      params: orig.config.params
-    }
-  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import axios, {AxiosError, AxiosResponse} from 'axios';
+import axios from 'axios';
 import * as rax from 'retry-axios';
 
 export const HOST_ADDRESS = 'http://metadata.google.internal';
@@ -13,10 +13,11 @@ export interface Options {
   property?: string;
 }
 
-// Accepts an options object passed from the user to the API.  In the
-// previous version of the API, it referred to a `Request` options object.
-// Now it refers to an Axios Request Config object.  This is here to help
-// ensure users don't pass invalid options when they upgrade from 0.4 to 0.5.
+// Accepts an options object passed from the user to the API. In previous
+// versions of the API, it referred to a `Request` or an `Axios` request
+// options object.  Now it refers to an object with very limited property
+// names. This is here to help ensure users don't pass invalid options when
+// they  upgrade from 0.4 to 0.5 to 0.8.
 function validate(options: Options) {
   Object.keys(options).forEach(key => {
     switch (key) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import axios, {AxiosError, AxiosResponse} from 'axios';
 import extend from 'extend';
-import * as http from 'http';
 import * as rax from 'retry-axios';
 
 export const HOST_ADDRESS = 'http://metadata.google.internal';

--- a/test/fixtures/kitchen/src/index.ts
+++ b/test/fixtures/kitchen/src/index.ts
@@ -9,6 +9,6 @@ async function main() {
   const v = await gcp.instance('/somepath');
 }
 
-gcp.project('something').then(x => console.log);
+gcp.project('something').then(console.log);
 
 main().catch(console.error);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -52,22 +52,8 @@ it('should accept an object with property and query fields', async () => {
                     .get(`${PATH}/project/${PROPERTY}`)
                     .query(QUERY)
                     .reply(200, {}, HEADERS);
-  const res = await gcp.project({property: PROPERTY, params: QUERY});
+  await gcp.project({property: PROPERTY, params: QUERY});
   scope.done();
-  assert(JSON.stringify(res.config.params), JSON.stringify(QUERY));
-  assert(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
-});
-
-it('should extend the request options', async () => {
-  const options = {property: PROPERTY, headers: {'Custom-Header': 'Custom'}};
-  const originalOptions = extend(true, {}, options);
-  const scope =
-      nock(HOST).get(`${PATH}/${TYPE}/${PROPERTY}`).reply(200, {}, HEADERS);
-  const res = await gcp.instance(options);
-  scope.done();
-  assert(res.config.url, `${BASE_URL}/${TYPE}/${PROPERTY}`);
-  assert(res.config.headers['Custom-Header'], 'Custom');
-  assert.deepStrictEqual(options, originalOptions);  // wasn't modified
 });
 
 it('should return the request error', async () => {


### PR DESCRIPTION
BREAKING CHANGE:  The `instance()` and `project()` methods are much more selective about which properties they will accept.  The only accepted properties are `params` and `properties`.

The `instance()` and `project()` methods also now directly return the data instead of a response object. 

---

I am trying to quarantine the types for Axios.  This makes it so we don't expose the underlying http client library. I am also making the set of acceptable properties you can pass into the options config an allow-list instead of an open obj, and checking it at runtime.  This is potentially very breaking, so I want thoughts here from @stephenplusplus and @ofrobots :)