### PR TITLE
refactor: use mocha instead of ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "main": "./build/src/index.js",
   "types": "./build/src/index.d.ts",
   "files": [
-    "LICENSE",
-    "README.md",
-    "build/src",
-    "package.json"
+    "build/src"
   ],
   "scripts": {
     "compile": "tsc -p .",
@@ -20,7 +17,7 @@
     "posttest": "npm run check",
     "prepare": "npm run compile",
     "test": "npm run test-only",
-    "test-only": "nyc ava build/test",
+    "test-only": "nyc mocha build/test",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json"
   },
   "keywords": [
@@ -41,18 +38,22 @@
   },
   "devDependencies": {
     "@types/extend": "^3.0.0",
+    "@types/mocha": "^5.2.4",
     "@types/ncp": "^2.0.1",
     "@types/nock": "^9.1.3",
     "@types/node": "^10.1.0",
     "@types/pify": "^3.0.2",
     "@types/tmp": "0.0.33",
-    "ava": "^0.25.0",
+    "assert-rejects": "^0.1.1",
     "codecov": "^3.0.2",
     "gts": "^0.7.0",
+    "hard-rejection": "^1.0.0",
+    "mocha": "^5.2.0",
     "ncp": "^2.0.0",
     "nock": "^9.2.6",
     "nyc": "^12.0.0",
     "pify": "^3.0.0",
+    "source-map-support": "^0.5.6",
     "tmp": "0.0.33",
     "typescript": "^2.8.3"
   },

--- a/test/kitchen.test.ts
+++ b/test/kitchen.test.ts
@@ -1,4 +1,3 @@
-import test from 'ava';
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import {ncp} from 'ncp';
@@ -35,20 +34,19 @@ const spawnp = (command: string, args: string[], options: cp.SpawnOptions = {}):
  * Create a staging directory with temp fixtures used to test on a fresh
  * application.
  */
-test('should be able to use the d.ts', async t => {
+it('should be able to use the d.ts', async () => {
   console.log(`${__filename} staging area: ${stagingPath}`);
   await spawnp('npm', ['pack']);
   const tarball = `${pkg.name}-${pkg.version}.tgz`;
   await rename(tarball, `${stagingPath}/${pkg.name}.tgz`);
   await ncpp('test/fixtures/kitchen', `${stagingPath}/`);
   await spawnp('npm', ['install'], {cwd: `${stagingPath}/`});
-  t.pass();
-});
+}).timeout(20000);
 
 /**
  * CLEAN UP - remove the staging directory when done.
  */
-test.after('cleanup staging', () => {
+after('cleanup staging', () => {
   if (!keep) {
     stagingDir.removeCallback();
   }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require hard-rejection/register
+--require source-map-support/register
+--timeout 10000


### PR DESCRIPTION
I switched this over to ava at some point.  That was a mistake.  I am trying to standardize our stuff on on mocha, and I wanted to get code coverage working better, so we're back here.  It's actually faster than ava in this case 😆 